### PR TITLE
RED-37222 redis-webcli fix tls configured bdbs

### DIFF
--- a/app.py
+++ b/app.py
@@ -18,9 +18,6 @@ from flask_redis_sentinel import SentinelExtension
 from flask_bootstrap import Bootstrap
 import redis_sentinel_url
 import redis
-from redis.sentinel import Sentinel
-from redis.connection import SSLConnection
-from redis import StrictRedis
 
 
 redis_sentinel = SentinelExtension()


### PR DESCRIPTION
It seems that when using a sentinel URL with the flask_redis_sentinel
module the connection sends the information in plain text to the server
that is expecting encryption. I tried configuring it to encrypt but could not.
As a workaround, separate the calls to sentinel and redis.py
 and communicate with redis.py using the ssl argument on creation of the handle.
Support configuration of SSL using environment variables.