### PR TITLE
Update apiVersion from v1beta1 to v1

### DIFF
--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: redis-webcli


### PR DESCRIPTION
apiVersion: v1beta1 is deprecated for Deployment