### PR TITLE
RED-181280 - support multiarch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,27 @@
-FROM python:3.8
+FROM python:3.11-bookworm
+
+# Docker automatically provides TARGETARCH (amd64, arm64, etc.) for multi-platform builds
+ARG TARGETARCH
+ARG MEMTIER_VERSION=2.1.1
 
 ENV FLASK_APP app.py
 ENV APP_SETTINGS settings.cfg
 ENV NO_URL_QUOTING True
+
+# Install memtier_benchmark from GitHub releases
+# Downloads the appropriate .deb file based on target architecture
+# Note: Version 2.1.1 is not available in the Redis APT repository, only on GitHub releases
+RUN curl -fsSL -o /tmp/memtier-benchmark.deb \
+        "https://github.com/RedisLabs/memtier_benchmark/releases/download/${MEMTIER_VERSION}/memtier-benchmark_${MEMTIER_VERSION}.bookworm_${TARGETARCH}.deb" && \
+    apt-get update && \
+    apt-get install -y --no-install-recommends /tmp/memtier-benchmark.deb && \
+    rm /tmp/memtier-benchmark.deb && \
+    rm -rf /var/lib/apt/lists/* && \
+    memtier_benchmark --version
+
 COPY . /app
 WORKDIR /app
 
 RUN pip install -r requirements.txt
-
-RUN make memtier_benchmark
 
 CMD python -m flask run -p 8080 -h 0.0.0.0

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,42 @@
 push: memtier_benchmark
 	cf push
 
+# Legacy target - no longer needed as memtier_benchmark is installed via APT in Dockerfile
 memtier_benchmark:
-	wget https://s3.eu-central-1.amazonaws.com/redislabs-dev-public-deps/binaries/memtier_benchmark_1.2.15_xenial
-	mv memtier_benchmark_1.2.15_xenial memtier_benchmark
-	chmod +x memtier_benchmark
+	@echo "memtier_benchmark is now installed via APT package in the Docker image"
+	@echo "This target is kept for backward compatibility only"
+
+# Docker multi-platform build targets
+.PHONY: docker-build docker-buildx-setup docker-push
+
+# Docker image configuration
+# Usage: make docker-push TAG=v1.2.3
+# To override image name: make docker-push IMAGE_NAME=myregistry/myimage TAG=v1.2.3
+# To override memtier version: make docker-push TAG=v1.2.3 MEMTIER_VERSION=2.1.4
+# WARNING: TAG is required for push commands to prevent accidental overwrites
+IMAGE_NAME ?= redislabs/redis-webcli
+TAG ?=
+MEMTIER_VERSION ?= 2.1.1
+
+# Setup buildx for multi-platform builds (run once)
+docker-buildx-setup:
+	docker buildx create --name multiarch --use || docker buildx use multiarch
+	docker buildx inspect --bootstrap
+
+# Build multi-platform image (AMD64 + ARM64)
+docker-build:
+	docker buildx build --platform linux/amd64,linux/arm64 \
+		--build-arg MEMTIER_VERSION=$(MEMTIER_VERSION) \
+		-t $(IMAGE_NAME):$(TAG) .
+
+# Build and push multi-platform image (requires TAG to be set)
+docker-push:
+	@if [ -z "$(TAG)" ]; then \
+		echo "Error: TAG is required. Usage: make docker-push TAG=v1.2.3"; \
+		exit 1; \
+	fi
+	docker buildx build --platform linux/amd64,linux/arm64 \
+		--build-arg MEMTIER_VERSION=$(MEMTIER_VERSION) \
+		-t $(IMAGE_NAME):$(TAG) --push .
+
+

--- a/app.py
+++ b/app.py
@@ -60,7 +60,7 @@ class MemtierThread(threading.Thread):
         self._process = None
 
     def run(self):
-        self._process = subprocess.Popen(["./memtier_benchmark", "-s", self._master_ip, "-p", self._master_port, "-a", self._redis_password] + self._argument_list,
+        self._process = subprocess.Popen(["memtier_benchmark", "-s", self._master_ip, "-p", self._master_port, "-a", self._redis_password] + self._argument_list,
                                            stdout=subprocess.PIPE, stderr=subprocess.STDOUT, bufsize=1, shell=False)
         while True:
             curr_output = self._process.stdout.readline().decode("utf-8")


### PR DESCRIPTION
** to build it we need to run:
`make docker-push IMAGE_NAME=redislabs/redis-webcli TAG=<tag-number>`